### PR TITLE
Added check to check for dollar sign in currency. Fixes WAC-140.

### DIFF
--- a/src/Validate.Lib/Validators/CurrencyValidator.cs
+++ b/src/Validate.Lib/Validators/CurrencyValidator.cs
@@ -10,6 +10,14 @@ namespace FormatValidator.Validators
             float parsed = 0;
             bool isValid = float.TryParse(toCheck, NumberStyles.Currency, CultureInfo.GetCultureInfo("en-US"), out parsed);
 
+
+            // Above expression didn't check to see if dollar sign is present, adding below condition to check for this:
+            if (isValid && toCheck[0] != '$')
+            {
+                isValid = false;
+            }
+
+
             if (!isValid)
             {
                 base.Errors.Add(new ValidationError(0, "Invalid value: value must be currency"));


### PR DESCRIPTION
There were no checks in place to determine that currency was preceded by a dollar sign. Therefore 2.50 would pass as a valid currency. Added condition to check the first character of the string to make sure that $ is in place. 